### PR TITLE
Update Kitware GPG key management

### DIFF
--- a/mp_rocker/templates/mp_kitware_cmake_snippet.Dockerfile.em
+++ b/mp_rocker/templates/mp_kitware_cmake_snippet.Dockerfile.em
@@ -9,14 +9,15 @@ RUN apt-get update \
         wget \
     && rm -rf /var/lib/apt/lists/*
 
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 
-RUN add-apt-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main"
+RUN echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && apt-get update
 
 RUN apt-get update \
     && apt-get install -y \
         cmake \
+    && rm /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && apt-get install -y \
         kitware-archive-keyring \
-    && rm -rf /var/lib/apt/lists/* \
-              /etc/apt/trusted.gpg.d/kitware.gpg
-
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Looks like something has changed in how the Kitware GPG keys are handled. Hopefully this fixes the problems.