### PR TITLE
Clang tools no version

### DIFF
--- a/mp_rocker/templates/mp_dev_helpers_snippet.Dockerfile.em
+++ b/mp_rocker/templates/mp_dev_helpers_snippet.Dockerfile.em
@@ -1,5 +1,5 @@
 # Development-related required and optional utils
-RUN DEBIAN_FRONTEND=noninteractive; \
+RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update \
     # Required packages
     && apt-get install -y \


### PR DESCRIPTION
Install non-versioned alias packages of the multiple clang tools included in the _dev helpers_.