### PR TITLE
Install Node.js LTS from NodeSource distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,10 @@ Install an up-to-date version of CMake from Kitware's own repository with, e.g.:
 ```
 rocker --mp-kitware-cmake ubuntu:bionic
 ```
+## NodeSource Node.js
 
+Install LTS version of Node.js from [NodeSource binary distributions](https://github.com/nodesource/distributions) with, e.g.:
+
+```bash
+rocker --mp-nodesource-nodejs ubuntu:bionic
+```

--- a/mp_rocker/nodesource_nodejs.py
+++ b/mp_rocker/nodesource_nodejs.py
@@ -1,0 +1,32 @@
+import em
+import pkgutil
+from rocker.extensions import RockerExtension
+
+
+class NodesourceNodejs(RockerExtension):
+
+    name = 'mp_nodesource_nodejs'
+
+    @classmethod
+    def get_name(cls):
+        return cls.name
+
+    def __init__(self):
+        self._env_subs = None
+        self.name = NodesourceNodejs.get_name()
+
+    def get_environment_subs(self):
+        if not self._env_subs:
+            self._env_subs = {}
+        return self._env_subs
+
+    def get_snippet(self, cliargs):
+        snippet = pkgutil.get_data('mp_rocker', 'templates/{}_snippet.Dockerfile.em'.format(self.name)).decode('utf-8')
+        return em.expand(snippet, self.get_environment_subs())
+
+    @staticmethod
+    def register_arguments(parser, defaults={}):
+        parser.add_argument('--mp-nodesource-nodejs',
+            action='store_true',
+            help='install Node.js from NodeSource binary distributions')
+

--- a/mp_rocker/templates/mp_nodesource_nodejs_snippet.Dockerfile.em
+++ b/mp_rocker/templates/mp_nodesource_nodejs_snippet.Dockerfile.em
@@ -1,0 +1,16 @@
+# Install Node.js from binary NodeSource distribution
+RUN apt-get update \
+    && apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg-agent \
+        software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash -
+
+RUN apt-get update \
+    && apt-get install -y \
+        nodejs \
+    && rm -rf /var/lib/apt/lists/*

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
             'mp_kitware_cmake = mp_rocker.kitware_cmake:KitwareCmake',
             'mp_nvim = mp_rocker.nvim:NVim',
             'mp_nvim_nightly = mp_rocker.nvim:NVimNightly',
+            'mp_nodesource_nodejs = mp_rocker.nodesource_nodejs:NodesourceNodejs',
         ]
     },
 )


### PR DESCRIPTION
Installs Node.js LTS from [NodeSource distributions](https://github.com/nodesource/distributions).

In particular this was required to support certain LSP servers automatically managed bv [williamboman/mason-lspconfig.nvim](williamboman/mason-lspconfig.nvim).